### PR TITLE
Add azure private token

### DIFF
--- a/backstage/templates/secret.yaml
+++ b/backstage/templates/secret.yaml
@@ -17,6 +17,7 @@ stringData:
   CIRCLECI_AUTH_TOKEN: {{ .Values.auth.circleciAuthToken }}
   GITHUB_ACCESS_TOKEN: {{ .Values.auth.githubAccessToken }}
   GITLAB_ACCESS_TOKEN: {{ .Values.auth.gitlabAccessToken }}
+  AZURE_PRIVATE_TOKEN: {{ .Values.auth.azurePrivateToken }}
 {{- end }}
 {{- if .Values.lighthouse.enabled }}
 ---

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -243,6 +243,7 @@ auth:
   # Used by the scaffolder to create GitHub repos. Must have 'repo' scope.
   githubAccessToken: g
   gitlabAccessToken: g
+  azurePrivateToken: h
 
 issuer:
   email: hello@example.com


### PR DESCRIPTION
Otherwise I get the following error when deploying the sample app.

```
» k logs backstage-backend-66758fc4c8-4rf8f                                                                                                                                                                                                                                                                                                                                                                                                                    1 ↵
FS-related option specified for migration configuration. This resets migrationSource to default FsMigrations
2020-10-06T04:33:59.200Z catalog info Beginning locations refresh
Backend failed to start up Error: Failed to initialize azure scaffolding provider, Missing required config value at 'scaffolder.azure.api.token'
    at createPlugin$4 (/usr/src/app/packages/backend/dist/index.cjs.js:142:15)
    at main (/usr/src/app/packages/backend/dist/index.cjs.js:247:38)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

I wanted to get a new version of [my demo app](https://backstage-demo.roadie.io/catalog/Component/sample-service-1) out.