### PR TITLE
Set the cert manager issuer to prod by default

### DIFF
--- a/backstage/templates/issuer.yaml
+++ b/backstage/templates/issuer.yaml
@@ -12,3 +12,18 @@ spec:
     - http01:
         ingress:
           class: nginx
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ .Values.issuer.email }}
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -59,6 +59,7 @@ fullnameOverride: ''
 
 ingress:
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: nginx
 
 global:


### PR DESCRIPTION
This commit also allows the ability to override the cert issuer
to be staging if neccessary.