### PR TITLE
Force SSL in backstage ingress

### DIFF
--- a/backstage/templates/ingress.yaml
+++ b/backstage/templates/ingress.yaml
@@ -7,11 +7,8 @@ metadata:
   name: {{ include "backstage.fullname" . }}-ingress
   {{- with .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($scheme = https) {
-      add_header  Strict-Transport-Security "max-age=0;";
-      }
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
This PR disables the previous annotations that allowed http connections.

These were useful for the backstage 1-click k8s installer as a demo but
we probably want to always have SSL enabled.