### PR TITLE
Add frontend, backend and lighthouse hosts to the ingress tls

### DIFF
--- a/backstage/templates/ingress.yaml
+++ b/backstage/templates/ingress.yaml
@@ -12,8 +12,13 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
   tls:
+    - secretName: {{ include "backstage.fullname" . }}-tls
+      hosts:
+        - {{ $frontendUrl.host }}
+        - {{ $backendUrl.host }}
+        - {{ $lighthouseUrl.host }}
+  {{- if .Values.ingress.tls }}
     {{- with .Values.ingress.tls }}
     {{- toYaml . | nindent 4 }}
     {{- end}}


### PR DESCRIPTION
This PR adds tls certificates at the backstage ingress for the backend, frontend and lighthouse hostnames by default. More tls options can be added through the chart's values.