### PR TITLE
Add support for external-secrets and secrets reloader

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -51,9 +51,10 @@ secretsSettings:
       description: Github PAT used for reading entity yaml files
     - name: GITHUB_CLIENT_ID
       internalName: AUTH_GITHUB_CLIENT_ID
-      description: Github Client ID
+      description: Client id for the Github oauth app
     - name: GITHUB_CLIENT_SECRET
       internalName: AUTH_GITHUB_CLIENT_SECRET
+      description: Client secret for the Github oauth app
     - name: GOOGLE_CLIENT_ID
       internalName: AUTH_GOOGLE_CLIENT_ID
       description: 'Google Client ID'

--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -39,6 +39,14 @@ catalog:
   locations: []
 {{- end }}
 
+{{- if .Values.externalSecrets.enabled }}
+secretsSettings:
+  ssm:
+    path: {{ required "path to SSM secrets .Values.externalSecrets.path is required" .Values.externalSecrets.path }}
+    keyId: {{ required "id or alias of the KMS key is required in .Values.externalSecrets.keyId" .Values.externalSecrets.keyId }}
+    region: {{ required ".Values.eternalSecrets.defaultRegion is required for accessing SSM parameters" .Values.externalSecrets.defaultRegion }}
+{{- end }}
+
 auth:
   providers:
     microsoft: null

--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -45,6 +45,21 @@ secretsSettings:
     path: {{ required "path to SSM secrets .Values.externalSecrets.path is required" .Values.externalSecrets.path }}
     keyId: {{ required "id or alias of the KMS key is required in .Values.externalSecrets.keyId" .Values.externalSecrets.keyId }}
     region: {{ required ".Values.eternalSecrets.defaultRegion is required for accessing SSM parameters" .Values.externalSecrets.defaultRegion }}
+  secrets:
+    - name: GITHUB_TOKEN
+      internalName: GITHUB_TOKEN
+      description: Github PAT used for reading entity yaml files
+    - name: GITHUB_CLIENT_ID
+      internalName: AUTH_GITHUB_CLIENT_ID
+      description: Github Client ID
+    - name: GITHUB_CLIENT_SECRET
+      internalName: AUTH_GITHUB_CLIENT_SECRET
+    - name: GOOGLE_CLIENT_ID
+      internalName: AUTH_GOOGLE_CLIENT_ID
+      description: 'Google Client ID'
+    - name: GOOGLE_CLIENT_SECRET
+      internalName: AUTH_GOOGLE_CLIENT_SECRET
+      description: Google Client Secret
 {{- end }}
 
 auth:

--- a/backstage/templates/_helpers.tpl
+++ b/backstage/templates/_helpers.tpl
@@ -284,3 +284,16 @@ app-config file name
 {{- define "backstage.appConfigFilename" -}}
 {{- "app-config.development.yaml" -}}
 {{- end -}}
+
+{{/*
+List of external secrets configured
+*/}}
+{{- define "backstage.externalSecretsList" -}}
+{{- $secrets := list -}}
+{{- range .Values.externalSecrets.secrets -}}
+{{- if .key -}}
+{{- $secrets = append $secrets .name  -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $secrets | quote -}}
+{{- end -}}

--- a/backstage/templates/backend-deployment.yaml
+++ b/backstage/templates/backend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/backstage.logs: '[{"source":"backstage","service":"backend"}]'
+        secret.reloader.stakater.com/reload: "github-token,github-client-id,github-client-secret"
       labels:
         app: backstage
         component: backend
@@ -40,6 +41,15 @@ spec:
                 name: {{ include "backstage.fullname" . }}-app-env
             - configMapRef:
                 name: {{ include "backstage.fullname" . }}-auth
+            # To make sure the keys in SSM parameters override the default chart values
+            # these secrets have to be the last ones
+            {{- if .Values.externalSecrets.enabled }}
+            {{- range .Values.externalSecrets.secrets }}
+            - secretRef:
+                name: {{ .name }}
+                optional: true
+            {{- end }}
+            {{- end }}
           env:
             - name: NODE_ENV
               value: {{ .Values.backend.nodeEnv | default "development" }}

--- a/backstage/templates/backend-deployment.yaml
+++ b/backstage/templates/backend-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         component: backend
 
     spec:
+      {{- if .Values.externalSecrets.enabled }}
+      serviceAccountName: {{ .Values.externalSecrets.serviceAccountName }}
+      {{- end }}
       {{- if .Values.dockerRegistrySecretName }}
       imagePullSecrets:
         - name: {{ .Values.dockerRegistrySecretName }}

--- a/backstage/templates/backend-deployment.yaml
+++ b/backstage/templates/backend-deployment.yaml
@@ -15,7 +15,9 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/backstage.logs: '[{"source":"backstage","service":"backend"}]'
-        secret.reloader.stakater.com/reload: "github-token,github-client-id,github-client-secret"
+        {{- if .Values.externalSecrets.enabled }}
+        secret.reloader.stakater.com/reload: {{ include "backstage.externalSecretsList" . }}
+        {{- end }}
       labels:
         app: backstage
         component: backend

--- a/backstage/templates/external-secrets.yaml
+++ b/backstage/templates/external-secrets.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.externalSecrets.enabled }}
+{{/* Verify  that the path ends with a slash*/}}
+{{- if not (hasSuffix  "/" (required "externalSecrets.path is required when externalSecrets.enable is true" .Values.externalSecrets.path)) }}
+  {{- fail (printf ".Values.externalSecrets.path should end with a `/`, got %s" .Values.externalSecrets.path) }}
+{{- end }}
+{{- range .Values.externalSecrets.secrets }}
+{{- if .key }}
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  annotations:
+  name: {{ .name }}
+spec:
+  backendType: systemManager
+  data:
+  - key: {{ printf "%s%s" ( required ".Values.externalSecrets.path is required when external secrets is enabled" $.Values.externalSecrets.path ) .key }}
+    name: {{ base .key}}
+  region: {{ .region | default $.Values.externalSecrets.defaultRegion }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/backstage/templates/external-secrets.yaml
+++ b/backstage/templates/external-secrets.yaml
@@ -1,8 +1,4 @@
 {{- if .Values.externalSecrets.enabled }}
-{{/* Verify  that the path ends with a slash*/}}
-{{- if not (hasSuffix  "/" (required "externalSecrets.path is required when externalSecrets.enable is true" .Values.externalSecrets.path)) }}
-  {{- fail (printf ".Values.externalSecrets.path should end with a `/`, got %s" .Values.externalSecrets.path) }}
-{{- end }}
 {{- range .Values.externalSecrets.secrets }}
 {{- if .key }}
 ---
@@ -14,7 +10,8 @@ metadata:
 spec:
   backendType: systemManager
   data:
-  - key: {{ printf "%s%s" ( required ".Values.externalSecrets.path is required when external secrets is enabled" $.Values.externalSecrets.path ) .key }}
+  {{/* clean avoids double `/` when joining the path and the key name*/}}
+  - key: {{ clean (printf "%s/%s" ( required ".Values.externalSecrets.path is required when external secrets is enabled" $.Values.externalSecrets.path ) .key )}}
     name: {{ base .key}}
   region: {{ .region | default $.Values.externalSecrets.defaultRegion }}
 {{- end }}

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -57,6 +57,21 @@ lighthouse:
 nameOverride: ''
 fullnameOverride: ''
 
+externalSecrets:
+  enabled: false
+  defaultRegion: eu-west-1
+  path:
+  secrets:
+    - name: github-token
+      key: GITHUB_TOKEN
+      region:
+    - name: github-client-id
+      key: AUTH_GITHUB_CLIENT_ID
+      region:
+    - name: github-client-secret
+      key: AUTH_GITHUB_CLIENT_SECRET
+      region:
+
 ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -61,16 +61,19 @@ externalSecrets:
   enabled: false
   defaultRegion: eu-west-1
   path:
+  keyId:
   secrets:
     - name: github-token
       key: GITHUB_TOKEN
       region:
     - name: github-client-id
       key: AUTH_GITHUB_CLIENT_ID
-      region:
     - name: github-client-secret
       key: AUTH_GITHUB_CLIENT_SECRET
-      region:
+    - name: google-client-id
+      key: AUTH_GOOGLE_CLIENT_ID
+    - name: google-client-secret
+      key: AUTH_GOOGLE_CLIENT_SECRET
 
 ingress:
   annotations:

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -59,6 +59,7 @@ fullnameOverride: ''
 
 externalSecrets:
   enabled: false
+  serviceAccountName: ssm-parameter-rw
   defaultRegion: eu-west-1
   path:
   keyId:


### PR DESCRIPTION
[Ch611 ]

This PR adds support for adding external secrets backed by AWS SSM parameters via a controller called `external-secrets`.

- External secrets are disabled by default but can easily be enabled by setting `externalSecrets.enabled=true` and `externalSecrets.path="/...../"`
- These secrets are, ~for now~, optional and added "on top" of the existing ones so that the chart continues to be backwards compatible for our demo cluster.
- The secrets can also be automatically reloaded in backstage through the [reloader]() via an annotation that the chart also adds when external secrets are enabled.

I tested these changes manually on test-demo-14 and roadie.roadie.so.

The changes are initially disabled by default so there _shouldn't_ be any changes happening in the prod clusters until it is enabled.