### PR TITLE
add backstage monitoring service

### DIFF
--- a/backstage/templates/backstage-monitor-deployment.yaml
+++ b/backstage/templates/backstage-monitor-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: roadie-backstage-monitor
+  name: roadie-backstage-monitor-deployment
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: roadie-backstage-monitor
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: roadie-backstage-monitor
+    spec:
+      containers:
+      - env:
+        - name: BACKSTAGE_ENDPOINT
+          value: http://{{ include "backstage.fullname" . }}-frontend
+        image: roadiehq/roadie-backstage-monitor
+        imagePullPolicy: Always
+        name: roadie-backstage-monitor
+        ports:
+        - containerPort: 9292
+          name: metrics
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: roadie-backstage-monitor-service
+
+spec:
+  ports:
+    - port: 9292
+      targetPort: 9292
+
+  selector:
+    app: roadie-backstage-monitor
+
+  type: ClusterIP


### PR DESCRIPTION
This adds a service to the cluster that monitors the customer deployment of backstage. If it is up it emits a metric backstage_up 0 and if it is down it will be 1. The metrics api is available on :9292/metrics