### PR TITLE
Revert "Add more definitions of other secrets that clients might want to set"

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -64,6 +64,15 @@ secretsSettings:
     - name: CIRCLECI_AUTH_TOKEN
       internalName: CIRCLECI_AUTH_TOKEN
       description: Token for the integration with CircleCI
+    - name: OKTA_CLIENT_ID
+      internalName: AUTH_OKTA_CLIENT_ID
+      description: Client secret for the Okta integration
+    - name: OKTA_CLIENT_SECRET
+      internalName: AUTH_OKTA_CLIENT_SECRET
+      description: Client secret for the Okta integration
+    - name: OKTA_AUDIENCE
+      internalName: AUTH_OKTA_AUDIENCE
+      description: Audience for the Okta integration
     - name: SENTRY_TOKEN
       internalName: SENTRY_TOKEN
       description: Token for Sentry integration

--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -61,24 +61,6 @@ secretsSettings:
     - name: GOOGLE_CLIENT_SECRET
       internalName: AUTH_GOOGLE_CLIENT_SECRET
       description: Google Client Secret
-    - name: CIRCLECI_AUTH_TOKEN
-      internalName: CIRCLECI_AUTH_TOKEN
-      description: Token for the integration with CircleCI
-    - name: OKTA_CLIENT_ID
-      internalName: AUTH_OKTA_CLIENT_ID
-      description: Client secret for the Okta integration
-    - name: OKTA_CLIENT_SECRET
-      internalName: AUTH_OKTA_CLIENT_SECRET
-      description: Client secret for the Okta integration
-    - name: OKTA_AUDIENCE
-      internalName: AUTH_OKTA_AUDIENCE
-      description: Audience for the Okta integration
-    - name: SENTRY_TOKEN
-      internalName: SENTRY_TOKEN
-      description: Token for Sentry integration
-    - name: ROLLBAR_ACCOUNT_TOKEN
-      internalName: ROLLBAR_ACCOUNT_TOKEN
-      description: Token for Rollbar
 {{- end }}
 
 auth:

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -83,6 +83,12 @@ externalSecrets:
       key: AUTH_GOOGLE_CLIENT_SECRET
     - name: circleci_auth_token
       key: CIRCLECI_AUTH_TOKEN
+    - name: auth_okta_client_id
+      key: AUTH_OKTA_CLIENT_ID
+    - name: auth_okta_client_secret
+      key: AUTH_OKTA_CLIENT_SECRET
+    - name: auth_okta_audience
+      key: AUTH_OKTA_AUDIENCE
     - name: sentry_token
       key: SENTRY_TOKEN
     - name: rollbar_account_token

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -81,18 +81,6 @@ externalSecrets:
       key: AUTH_GOOGLE_CLIENT_ID
     - name: google-client-secret
       key: AUTH_GOOGLE_CLIENT_SECRET
-    - name: circleci_auth_token
-      key: CIRCLECI_AUTH_TOKEN
-    - name: auth_okta_client_id
-      key: AUTH_OKTA_CLIENT_ID
-    - name: auth_okta_client_secret
-      key: AUTH_OKTA_CLIENT_SECRET
-    - name: auth_okta_audience
-      key: AUTH_OKTA_AUDIENCE
-    - name: sentry_token
-      key: SENTRY_TOKEN
-    - name: rollbar_account_token
-      key: ROLLBAR_ACCOUNT_TOKEN
 
 ingress:
   annotations:


### PR DESCRIPTION
Reverts RoadieHQ/helm-charts#29

This appears to have caused the following errors when deploying a new cluster:

```  Warning  FailedReleaseSync  2m22s (x3 over 3m12s)  helm-operator  synchronization of release 'default-backstage' in namespace 'default' failed: installation failed: Deployment.apps "default-backstage-backend" is invalid: [spec.template.spec.containers[0].envFrom[8].secretRef.name: Invalid value: "circleci_auth_token": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.containers[0].envFrom[9].secretRef.name: Invalid value: "sentry_token": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.containers[0].envFrom[10].secretRef.name: Invalid value: "rollbar_account_token": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]```