### PR TITLE
Add more secret definitions for circleci, sentry and rollbar

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -61,6 +61,15 @@ secretsSettings:
     - name: GOOGLE_CLIENT_SECRET
       internalName: AUTH_GOOGLE_CLIENT_SECRET
       description: Google Client Secret
+    - name: CIRCLECI_AUTH_TOKEN
+      internalName: CIRCLECI_AUTH_TOKEN
+      description: Token for the integration with CircleCI
+    - name: SENTRY_TOKEN
+      internalName: SENTRY_TOKEN
+      description: Token for Sentry integration
+    - name: ROLLBAR_ACCOUNT_TOKEN
+      internalName: ROLLBAR_ACCOUNT_TOKEN
+      description: Token for Rollbar
 {{- end }}
 
 auth:

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -81,6 +81,12 @@ externalSecrets:
       key: AUTH_GOOGLE_CLIENT_ID
     - name: google-client-secret
       key: AUTH_GOOGLE_CLIENT_SECRET
+    - name: circleci-auth-token
+      key: CIRCLECI_AUTH_TOKEN
+    - name: sentry-token
+      key: SENTRY_TOKEN
+    - name: rollbar-account-token
+      key: ROLLBAR_ACCOUNT_TOKEN
 
 ingress:
   annotations:


### PR DESCRIPTION
This adds more options on the secrets page so that customers can configure the integrations with circleci, rollbar and sentry through the UI.

Part of epic [Ch886]