### PR TITLE
Configure techradar through env vars

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -108,7 +108,3 @@ single-sign-on:
   config:
     cookieName: VouchCookie
 
-{{- if .Values.appConfig.techradar }}
-techradar:
-  {{- toYaml .Values.appConfig.techradar | nindent 2 }}
-{{- end }}

--- a/backstage/templates/backstage-app-config.yaml
+++ b/backstage/templates/backstage-app-config.yaml
@@ -27,4 +27,8 @@ data:
   APP_CONFIG_auth_providers_gitlab_development_appOrigin: {{ .Values.appConfig.auth.providers.gitlab.development.appOrigin | quote | quote }}
   APP_CONFIG_auth_providers_okta_development_appOrigin: {{ .Values.appConfig.auth.providers.okta.development.appOrigin | quote | quote }}
   APP_CONFIG_auth_providers_oauth2_development_appOrigin: {{ .Values.appConfig.auth.providers.oauth2.development.appOrigin | quote | quote }}
-
+  {{- if .Values.appConfig.techradar }}
+  {{- range $key, $value := .Values.appConfig.techradar.source }}
+  APP_CONFIG_techradar_source_{{$key}}: {{ $value | quote | quote }}
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
We need to set these at runtime.

Regarding testing I don't have a dev cluster to test these so I've only run the `template` cli command and inspected the output. I hope to create one tomorrow as I'd rather not test on roadie.so if I can avoid it.