### PR TITLE
allow the configuration of a custom field for use as userId

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -107,4 +107,7 @@ single-sign-on:
   name: vouch
   config:
     cookieName: VouchCookie
+    {{- if .Values.singleSignOn.vouch.customUserIdFieldName }}
+    customUserIdFieldName: {{ .Values.singleSignOn.vouch.customUserIdFieldName }}
+    {{- end }}
 

--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -33,6 +33,9 @@ backend:
     limits:
       memory: 1024Mi
 
+singleSignOn:
+  vouch: {}
+
 monitor:
   image:
     repository: roadiehq/roadie-backstage-monitor


### PR DESCRIPTION
This change allows the single sign on backend to be configured to
use a different field for the backstage logged in username.

This faciliates the users in okta to be mapped to the users a
github organization team structure.