### PR TITLE
Reload deployments automatically when configmap or secrets change

### DIFF
--- a/backstage/templates/backend-deployment.yaml
+++ b/backstage/templates/backend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         ad.datadoghq.com/backstage.logs: '[{"source":"backstage","service":"backend"}]'
         {{- if .Values.externalSecrets.enabled }}
-        secret.reloader.stakater.com/reload: {{ include "backstage.externalSecretsList" . }}
+        reloader.stakater.com/auto: "true"
         {{- end }}
       labels:
         app: backstage

--- a/backstage/templates/frontend-deployment.yaml
+++ b/backstage/templates/frontend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         ad.datadoghq.com/backstage.logs: '[{"source":"backstage","service":"frontend"}]'
+        reloader.stakater.com/auto: "true"
       labels:
         app: backstage
         component: frontend


### PR DESCRIPTION
I am adding this because I noticed that helm-operator doesn't always restart
the deployments when a new configmap or secret has changed. This means that
changes do not actually take effect when we expect.

By adding this annotation, the reloader controller will restart the frontend
and backend deployments when any configmap or secret is updated. We can test
it and go back to a limited amount of data sources in the annotation if we
see it restarts too often or does something strange.

(note: copy of the same pr in the helm-charts repo)