### PR TITLE
Remove the lighthouse route

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -108,7 +108,6 @@ authenticatedProxy:
 {{- end }}
 
 proxy:
-  '/lighthouse': http://{{ include "lighthouse.serviceName" . }}
   {{- toYaml .Values.appConfig.proxy | nindent 4 }}
 
   {{- if .Values.appConfig.jiraProxy.enabled }}


### PR DESCRIPTION
It appears to be preventing the backend to start as it's invalid (roadie.roadie.so). Given we've removed (or should have) lighthouse from the UI we can/should remove the proxy entry too. There's probably more clean up to do but we should try bring back roadie.roadie.so asap.

Error:
Backend failed to start up Error: Proxy target is not a valid URL: http://default-backstage-lighthouse null