### PR TITLE
Fix proxy config for lighthouse

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -108,8 +108,13 @@ authenticatedProxy:
 {{- end }}
 
 proxy:
-  '/lighthouse': http://{{ include "lighthouse.serviceName" . }}
+{{- if .Values.lighthouse.enabled }}
+  '/lighthouse':
+    target: http://{{ include "lighthouse.serviceName" .  }}
+{{- end }}
+{{- if .Values.appConfig.proxy }}
   {{- toYaml .Values.appConfig.proxy | nindent 4 }}
+{{- end }}
 
   {{- if .Values.appConfig.jiraProxy.enabled }}
   '/jira/api':


### PR DESCRIPTION
## Before

```
    proxy:
      '/lighthouse': http://default-backstage-lighthouse
        null
      '/jira/api':
        target:
          $env:
            JIRA_API_URL
        headers:
          Authorization:
            $env:
              JIRA_API_TOKEN
          Accept: 'application/json'
          Content-Type: 'application/json'
          X-Atlassian-Token: 'no-check'
          User-Agent: "Roadie-Backstage"
```

## After

```
    proxy:
      '/lighthouse':
        target: http://default-backstage-lighthouse
      '/jira/api':
        target:
          $env:
            JIRA_API_URL
        headers:
          Authorization:
            $env:
              JIRA_API_TOKEN
          Accept: 'application/json'
          Content-Type: 'application/json'
          X-Atlassian-Token: 'no-check'
          User-Agent: "Roadie-Backstage"
    
```