### PR TITLE
Use Issuer instead of ClusterIssuer

### DIFF
--- a/backstage/templates/issuer.yaml
+++ b/backstage/templates/issuer.yaml
@@ -1,5 +1,5 @@
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-prod
 spec:
@@ -14,7 +14,7 @@ spec:
           class: nginx
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-staging
 spec:


### PR DESCRIPTION
Hi,
I just noticed that when deploying the backstage chart, it wanted to deploy a `ClusterIssuer`, which seems too much. I think it might be enough with just an `Issuer` (which thus acts only in that namespace where this chart has been deployed). Especially given that it hasn't been named/prefixed for just `backstage`, it may surprise others when they get a new cluster-global issuer that any services in the cluster can use.

See their docs for details: https://cert-manager.io/docs/concepts/issuer/