### PR TITLE
Workaround jira proxy default not working after upgrade

### DIFF
--- a/backstage/values.yaml
+++ b/backstage/values.yaml
@@ -157,7 +157,7 @@ appConfig:
   rollbar:
     organization: roadie
   jiraProxy:
-    enabled: true
+    enabled: false
 
   # Auth config has recently moved into the app config file in upstream Backstage. However,
   # most of this config simply mandates that items like the client id and client secret should


### PR DESCRIPTION
[Ch1751]


This is a workaround for the backend not starting with the jiraPRoxy enabled and
a dummy value in the JIRA_API_URL env var as a default.

After an upgrade from upstream this does not work anymore because the proxy has 
more strict valudation rules and makes the backend crash with:

```
2021-03-29T15:17:33.390Z proxy info [HPM] Proxy rewrite rule created: "^/api/proxy/lighthouse/" ~> "/" type=plugin
Backend failed to start up Error: Proxy target is not a valid URL: unset
    at buildMiddleware (/usr/src/app/plugins/proxy-backend/dist/index.cjs.js:32:11)
    at /usr/src/app/plugins/proxy-backend/dist/index.cjs.js:80:23
    at Array.forEach (<anonymous>)
    at Object.createRouter (/usr/src/app/plugins/proxy-backend/dist/index.cjs.js:79:31)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async createPlugin$6 (/usr/src/app/packages/backend/dist/index.cjs.js:205:10)
    at async main (/usr/src/app/packages/backend/dist/index.cjs.js:355:27)
```