### PR TITLE
Prefix jira token for basic auth

### DIFF
--- a/backstage/files/app-config.development.yaml.tpl
+++ b/backstage/files/app-config.development.yaml.tpl
@@ -130,9 +130,7 @@ proxy:
       $env:
         JIRA_API_URL
     headers:
-      Authorization:
-        $env:
-          JIRA_API_TOKEN
+      Authorization: 'Basic ${JIRA_API_TOKEN}'
       Accept: 'application/json'
       Content-Type: 'application/json'
       X-Atlassian-Token: 'no-check'


### PR DESCRIPTION
We still require the user to generate the
basic auth string but prefix the string
with 'Basic ' so they don't have to.