### PR TITLE
default secret data to empty strings

### DIFF
--- a/sample-service/values.yaml
+++ b/sample-service/values.yaml
@@ -10,9 +10,9 @@ image:
   pullPolicy: IfNotPresent
 
 appConfig:
-  rollbarAccessToken:
-  sentryIngestionUrl:
-  newRelicLicenseKey:
+  rollbarAccessToken: ""
+  sentryIngestionUrl: ""
+  newRelicLicenseKey: ""
   nodeEnv: production
 
 containerPort: 3000


### PR DESCRIPTION
This is a bit of a hacky solution but it gets us around the following error

unknown object type "nil" in Secret.stringData.NEW_RELIC_LICENSE_KEY

 ch3494