### PR TITLE
dont add BROKER_TOKEN if token is not provided

### DIFF
--- a/roadie-broker/templates/broker.yaml
+++ b/roadie-broker/templates/broker.yaml
@@ -34,8 +34,10 @@ spec:
           image: {{ .Values.broker.image }}
           imagePullPolicy: Always
           env:
+            {{- if .Values.broker.token }}
             - name: BROKER_TOKEN
               value: {{ .Values.broker.token }}
+            {{- end }}
             - name: BROKER_SERVER_URL
               value: https://{{ .Values.broker.tenantName }}.broker.roadie.so
             - name: CA_CERTS


### PR DESCRIPTION
Don't add the BROKER_TOKEN env variable if the token value is not provided. This will allow to configure the BROKER_TOKEN environment variable through the envFrom section and use secrets for it.