### PR TITLE
pin roadie agent to working version

### DIFF
--- a/roadie-kubernetes-cluster-access/Chart.yaml
+++ b/roadie-kubernetes-cluster-access/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roadie-kubernetes-cluster-access
 description: Allows read access from Roadie Backstage to a Kubernetes cluster
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: 0.1.9
 sources:
   - https://github.com/RoadieHQ/helm-charts

--- a/roadie-kubernetes-cluster-access/values.yaml
+++ b/roadie-kubernetes-cluster-access/values.yaml
@@ -1,7 +1,7 @@
 
 broker:
   enabled: false
-  image: "roadiehq/broker:kubernetes"
+  image: "roadiehq/broker:13371353312.75.1-kubernetes"
   imagePullSecret:
   logLevel: debug
   logBody: false


### PR DESCRIPTION
I tested this by running the latest version of the helm chart to replicate the issue, then I set the broker.image value override in my help deployment and it resolved the issue.